### PR TITLE
Single cam

### DIFF
--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -272,12 +272,9 @@ def parse_arguments(arguments):
     parser.add_argument('--exposure-time', dest='exposure_time',
                         action='store', type=float, default=0.15,
                         metavar='EXPOSURE-TIME',
-                        help='exposure time for both cameras')
-    parser.add_argument('cam1_uri', action='store', type=str,
-                        metavar='CAM1-URI',nargs='+', help='URI for camera #1')
-#    parser.add_argument('cam2_uri', action='store', type=str,
-#                        default=None, required=False,
-#                        metavar='CAM2-URI', help='URI for camera #2')
+                        help='exposure time for camera(s), default 0.15 s')
+    parser.add_argument('cam_uri', action='store', type=str,
+                        metavar='CAM-URI',nargs='+', help='URI for 1 or 2 camera(s) each of the form PYRO:[microscope_device_name]@[ip_address]:[port]')
     return parser.parse_args(arguments[1:])
 
 
@@ -292,16 +289,7 @@ def __main__():
 
     "PYRO:[microscope_device_name]@[ip_address]:[port]"
     """
-    if len(sys.argv) < 2:
-        print("\nToo few parguments.\n", file=sys.stderr)
-        print(__main__.__doc__, file=sys.stderr)
-        sys.exit(1)
-    elif len(sys.argv) > 5:
-        print("\nToo many arguments.\n", file=sys.stderr)
-        print(__main__.__doc__, file=sys.stderr)
-        sys.exit(1)
-    else:
-        contructUI(sys.argv)
+    contructUI(sys.argv)
 
 
 
@@ -313,9 +301,9 @@ def contructUI(argv):
 
     args = parse_arguments(app.arguments())
 
-    cam1 = Imager(args.cam1_uri[0], args.exposure_time)
-    if len (args.cam1_uri)==2:
-        cam2 = Imager(args.cam1_uri[1], args.exposure_time)
+    cam1 = Imager(args.cam_uri[0], args.exposure_time)
+    if len (args.cam_uri)==2:
+        cam2 = Imager(args.cam_uri[1], args.exposure_time)
     else:
         cam2=None
         

--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -301,6 +301,10 @@ def contructUI(argv):
 
     args = parse_arguments(app.arguments())
 
+    if(len(args.cam_uri)>2):
+        print("Error: Too many cam_uri entries BeamDelta can only handle two cameras")
+        exit()
+
     cam1 = Imager(args.cam_uri[0], args.exposure_time)
     if len (args.cam_uri)==2:
         cam2 = Imager(args.cam_uri[1], args.exposure_time)

--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -138,7 +138,7 @@ def compute_beam_centre(image):
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, imager1, imager2, parent=None):
+    def __init__(self, imager1, imager2=None, parent=None):
         super().__init__(parent)
         self.setCentralWidget(CentralWidget(self, imager1, imager2))
 
@@ -153,14 +153,16 @@ class MainWindow(QMainWindow):
         self.setWindowState(self.windowState() ^ Qt.WindowFullScreen)
 
 class CentralWidget(QWidget):
-    def __init__(self, parent, imager1, imager2):
+    def __init__(self, parent, imager1, imager2=None):
         super().__init__(parent)
         self.camera1 = AlignmentControl(imager1)
-        self.camera2 = AlignmentControl(imager2)
+        if imager2:
+            self.camera2 = AlignmentControl(imager2)
 
         layout = QHBoxLayout(self)
         layout.addWidget(self.camera1)
-        layout.addWidget(self.camera2)
+        if imager2:
+            layout.addWidget(self.camera2)
         self.setLayout(layout)
 
 
@@ -272,9 +274,10 @@ def parse_arguments(arguments):
                         metavar='EXPOSURE-TIME',
                         help='exposure time for both cameras')
     parser.add_argument('cam1_uri', action='store', type=str,
-                        metavar='CAM1-URI', help='URI for camera #1')
-    parser.add_argument('cam2_uri', action='store', type=str,
-                        metavar='CAM2-URI', help='URI for camera #2')
+                        metavar='CAM1-URI',nargs='+', help='URI for camera #1')
+#    parser.add_argument('cam2_uri', action='store', type=str,
+#                        default=None, required=False,
+#                        metavar='CAM2-URI', help='URI for camera #2')
     return parser.parse_args(arguments[1:])
 
 
@@ -289,9 +292,9 @@ def __main__():
 
     "PYRO:[microscope_device_name]@[ip_address]:[port]"
     """
-
-    if len(sys.argv) < 3:
-        print("\nToo few arguments.\n", file=sys.stderr)
+    print ("len=",len(sys.argv))
+    if len(sys.argv) < 2:
+        print("\nToo few parguments.\n", file=sys.stderr)
         print(__main__.__doc__, file=sys.stderr)
         sys.exit(1)
     elif len(sys.argv) > 5:
@@ -311,9 +314,12 @@ def contructUI(argv):
 
     args = parse_arguments(app.arguments())
 
-    cam1 = Imager(args.cam1_uri, args.exposure_time)
-    cam2 = Imager(args.cam2_uri, args.exposure_time)
-
+    cam1 = Imager(args.cam1_uri[0], args.exposure_time)
+    if len (args.cam1_uri)==2:
+        cam2 = Imager(args.cam1_uri[1], args.exposure_time)
+    else:
+        cam2=None
+        
     window = MainWindow(imager1=cam1, imager2=cam2)
     window.show()
     return app.exec()

--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -302,7 +302,7 @@ def contructUI(argv):
     args = parse_arguments(app.arguments())
 
     if(len(args.cam_uri)>2):
-        print("Error: Too many cam_uri entries BeamDelta can only handle two cameras")
+        print("Error: Too many cam_uri entries BeamDelta can only handle two cameras, \n\tuse \"BeamDelta -h\" for full help")
         exit()
     cam1 = Imager(args.cam_uri[0], args.exposure_time)
     if len (args.cam_uri)==2:

--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -292,7 +292,6 @@ def __main__():
 
     "PYRO:[microscope_device_name]@[ip_address]:[port]"
     """
-    print ("len=",len(sys.argv))
     if len(sys.argv) < 2:
         print("\nToo few parguments.\n", file=sys.stderr)
         print(__main__.__doc__, file=sys.stderr)

--- a/BeamDelta/BeamDeltaUI.py
+++ b/BeamDelta/BeamDeltaUI.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import (QApplication, QHBoxLayout, QLabel, QMainWindow,
                              QCheckBox, QPushButton, QShortcut, QVBoxLayout,
                              QWidget)
 
-from PyQt5.QtGui import QImage, QKeySequence, QPainter, QPen
+from PyQt5.QtGui import QImage, QKeySequence, QPainter, QPen, QFont
 
 from PyQt5.QtCore import(QObject, QPoint, QSize, QTimer, Qt,
                          pyqtSignal, pyqtSlot)
@@ -209,7 +209,7 @@ class AlignmentText(QLabel):
 
         self._alignment = alignment
         self._alignment.changed.connect(self.updateText)
-
+        self.setFont(QFont('SansSerif',18))
         self.updateText()
 
     @pyqtSlot()
@@ -304,7 +304,6 @@ def contructUI(argv):
     if(len(args.cam_uri)>2):
         print("Error: Too many cam_uri entries BeamDelta can only handle two cameras")
         exit()
-
     cam1 = Imager(args.cam_uri[0], args.exposure_time)
     if len (args.cam_uri)==2:
         cam2 = Imager(args.cam_uri[1], args.exposure_time)


### PR DESCRIPTION
This pull request allows one or two cameras to be specified on the command line, generating an interface with one or two cameras. 

Needs the help text clarified but I am confused as to why we have both default help text and argparser generating help text. should we not just get rid of the defualt text?